### PR TITLE
use $.getJSON instead of $.get

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -4,7 +4,7 @@ var BANNED_LINKS = [
 ];
 
 $(function () {
-  $.get('sites.json', function (parsed) {
+  $.getJSON('sites.json', function (parsed) {
     // Web browsers change the URL after it is added.
     var formatted = {};
 


### PR DESCRIPTION
$.getJSON work better, $.getJSON make it working on local in Firefox, and working in Chrome with [`--allow-file-access-from-files`](http://www.chrome-allow-file-access-from-file.com/) option
